### PR TITLE
ENH-005: Reconfigured the layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,52 @@
 # jinius's zmk-config
 
-This is my personal [ZMK firmware](https://github.com/zmkfirmware/zmk/) configuration.
-This is for my 42-keys corne keyboard.
+Personal [ZMK firmware](https://github.com/zmkfirmware/zmk/) configuration repo for my 42-keys corne keyboard.
 
-This branch is updated for the latest ZMK firmware.
+I use this for my work and personal Mac and my Old Windows laptop revitalized using Linux Mint. 
 
-## Tasks for Highlights
-- create a layer layout as mentioned by [Miryoku ZMK](https://github.com/manna-harbour/miryoku_zmk)
-- add urob's [zmk-nodefree-config](https://github.com/urob/zmk-nodefree-config) to add functionality
-- enable local and github action build for all the release versions
-- use [Caps Word](https://zmk.dev/docs/behaviors/caps-word) in place of <kbd>Caps Lock</kbd>.
-- prefer [Toggle Layer](https://zmk.dev/docs/behaviors/layers#toggle-layer) along with [Tap Dance](https://zmk.dev/docs/behaviors/tap-dance) to work on a layer
-- configure [mouse keys on the host](https://en.wikipedia.org/wiki/Mouse_keys) by following the steps mentioned at [Miryoku ZMK](https://github.com/manna-harbour/miryoku_zmk#mouse-keys)
-- provide a keymap image file using one of these options (or may be all of them): [keymap-drawer](https://github.com/caksoylar/keymap-drawer), [Keymap Editor](https://github.com/nickcoutsos/keymap-editor#keymap-editor)
-- register the repo with [KeymapDB](https://keymapdb.com/) at some point in time
+---
+
+> [!WARNING]\
+> Under **_active development_**. Items to be added are highlighted under **Tasks**
+
+> [!NOTE]\
+> This layout is primarily designed for learning **[Colemak-DH](https://colemakmods.github.io/mod-dh/)** to help me migrate from **QWERTY** layout, where I have built my muscle memory.
+> 
+
+---
+
+
+## Highlight [v2.0.0]
+- Layers as mentioned by [Miryoku ZMK](https://github.com/manna-harbour/miryoku_zmk)
+- Prefer [Toggle Layer](https://zmk.dev/docs/behaviors/layers#toggle-layer) along with [Tap Dance](https://zmk.dev/docs/behaviors/tap-dance) to work on a layer
+- Switching between Mac & Win as mentioned [How To Mimic QMK’s CG_TOGG or AG_TOGG OS Key Switching Behavior In ZMK](https://flatfootfox.com/how-to-mimic-qmks-cg_togg-or-ag_togg-os-key-switching-behavior-in-zmk/)
+- Home Row Mods setup for trial as mentioned [A guide to home row mods](https://precondition.github.io/home-row-mods)
+- Trial of [Timeless homerow mods](https://github.com/urob/zmk-config#timeless-homerow-mods)
+- Preference to [&none](https://zmk.dev/docs/behaviors/misc#none) instead of [&trans](https://zmk.dev/docs/behaviors/misc#transparent)
+
+
+## Highlight [v1.0.0]
+- Default set-up as provided by intial zmk firmware setup
+
+
+## Items for next release
+- Urob's [zmk-nodefree-config](https://github.com/urob/zmk-nodefree-config) to add functionality
+- Enable local and github action build for all the release versions
+- Use [Caps Word](https://zmk.dev/docs/behaviors/caps-word) in place of <kbd>Caps Lock</kbd>.
+- Configure [mouse keys on the host](https://en.wikipedia.org/wiki/Mouse_keys) by following the steps mentioned at [Miryoku ZMK](https://github.com/manna-harbour/miryoku_zmk#mouse-keys)
+- Provide a keymap image file using one of these options (or may be all of them): [keymap-drawer](https://github.com/caksoylar/keymap-drawer), [Keymap Editor](https://github.com/nickcoutsos/keymap-editor#keymap-editor)
+- Register the repo with [KeymapDB](https://keymapdb.com/) at some point in time
+
 
 ## References
 - My journey towards using split keyboard, specifically corne with nice!nano v2.0, was inspired by [Josean Martinez](https://www.josean.com/) and his video about the keyboard (https://youtu.be/wTMcH7u-vu0?si=mLIXluwT_KchNSwd)
 - My keboard source: [Typeractive](https://typeractive.xyz/)
+- [ZMK Firmware GitHub](https://github.com/zmkfirmware/zmk)
+- [ZMK Documentation](https://zmk.dev/docs)
+- Various config repos collected @[KeymapDB](https://keymapdb.com/)
+  - [Knucklehead](https://github.com/minusfive/zmk-config)
+  - [Miryoku ZMK](https://github.com/manna-harbour/miryoku_zmk)
+  - [caksoylar](https://github.com/caksoylar/zmk-config)
+  - [urob](https://github.com/urob/zmk-config)
+  - More to be added as I go add more features to my current config
+

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -4,53 +4,622 @@
  * SPDX-License-Identifier: MIT
  */
 
+// INCLUDES - START  ***********************************************************
+// ZMK Core Includes
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+// JINIUS Includes
+// Key position includes
+#include "corne_42keys.h"
+// INCLUDES - ENDS *************************************************************
+
+// DEFINES - START *************************************************************
+// DEFINES LAYERS - START ******************************************************
+// Layer shotcuts defined for easier identification.
+// The order must match in which they are defined below.
+#define QWT__BT 0
+#define FN__NUM 1
+#define SYMBOLS 2
+#define BT__NAV 3
+#define CDH__BT 4
+// DEFINES LAYERS - ENDS *******************************************************
+// DEFINES BLUETOOTH PROFILE SELECTION - START *********************************
+#define BTP0 BT_SEL 0
+#define BTP1 BT_SEL 1 
+#define BTP2 BT_SEL 2
+#define BTP3 BT_SEL 3
+#define BTP4 BT_SEL 4
+// DEFINES BLUETOOTH PROFILE SELECTION - ENDS **********************************
+
+// DEFINES KEY TYPE ALIAS - START **********************************************
+#define XXX &none   // To trap the key event in a given layer
+#define ___ &trans  // To pass the key event to the next active layer
+// DEFINES KEY TYPE ALIAS - ENDS ***********************************************
+
+// DEFINES GLOBAL SETTINGS - START *********************************************
+#define QUICK_TAP_MS 175
+// DEFINES GLOBAL SETTINGS - ENDS **********************************************
+
+// DEFINES KEY CONFIGURATION SETTINGS - START **********************************
+&sk {  // sticky-key config
+    release-after-ms = <900>;  // release after 0.6s
+    quick-release;             // no double capitalization when rolling keys
+};
+
+&sl {  // sticky-layer config
+    ignore-modifiers;          // allow chording sticky mods & layers
+};
+
+&lt {  // layer-tap config
+    flavor = "balanced";
+    tapping-term-ms = <200>;
+    quick-tap-ms = <QUICK_TAP_MS>;
+};
+// DEFINES KEY CONFIGURATION SETTINGS - ENDS ***********************************
+
+// DEFINES COMBINATION KEYS FOR HOMEROW MODS - START ***************************
+#define LEFT_HAND_KEYS LT0 LT1 LT2 LT3 LT4 LT5 LM0 LM1 LM2 LM3 LM4 LM5 LB0 LB1 LB2 LB3 LB4 LB5
+#define RIGHT_HAND_KEYS RT0 RT1 RT2 RT3 RT4 RT5 RM0 RM1 RM2 RM3 RM4 RM5 RB0 RB1 RB2 RB3 RB4 RB5
+#define THUMB_KEYS LH0 LH1 LH2 RH0 RH1 RH2
+// DEFINES COMBINATION KEYS FOR HOMEROW MODS - ENDS ****************************
+
+
+// DEFINES - ENDS **************************************************************
+
+// ROOT DEVICETREE NODE - START ************************************************
+/ {
+
+// COMBOS - START **************************************************************
+// REF: https://zmk.dev/docs/features/combos
+// NOTES: Need to figure out if a specific combo is needed.
+//    > Possible combo would be <SHIFT> + <COMMAND> + <OPTION> + V in mac to
+//      paste the clipboard content as plain text
+// COMBOS - ENDS ***************************************************************
+
+// BEHAVIOR - START ************************************************************
+/*
+// SAMPLE CODE 01: TOGGLE-ON-TAP, MOMENTARY-ON-HOLD LAYERS
+// https://zmk.dev/docs/behaviors/hold-tap
+// Hold-Tap Example: Momentary layer on Hold, Toggle layer on Tap
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+
+#define MO_TOG(layer) &mo_tog layer layer   // Macro to apply momentary-layer-on-hold/toggle-layer-on-tap to a specific layer
 
 / {
-        keymap {
-                compatible = "zmk,keymap";
-
-                default_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BKSP |
-// | CTRL |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
-// | SHFT |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | ESC  |
-//                    | GUI | LWR | SPC |   | ENT | RSE  | ALT |
-                        bindings = <
-   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
-   &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
-   &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp ESC
-                  &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 2 &kp RALT
-                        >;
-                };
-                lower_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | BKSP |
-// | BTCLR| BT1 | BT2 | BT3 | BT4 | BT5 |   | LFT | DWN |  UP | RGT |     |      |
-// | SHFT |     |     |     |     |     |   |     |     |     |     |     |      |
-//                    | GUI |     | SPC |   | ENT |     | ALT |
-                        bindings = <
-   &kp TAB    &kp N1       &kp N2       &kp N3       &kp N4       &kp N5         &kp N6   &kp N7   &kp N8 &kp N9    &kp N0 &kp BSPC
-   &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4   &kp LEFT &kp DOWN &kp UP &kp RIGHT &trans &trans
-   &kp LSHFT  &trans       &trans       &trans       &trans       &trans         &trans   &trans   &trans &trans    &trans &trans
-                                    &kp LGUI     &trans       &kp SPACE      &kp RET  &trans   &kp RALT
-                        >;
-                };
-
-                raise_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  | BKSP |
-// | CTRL |     |     |     |     |     |   |  -  |  =  |  [  |  ]  |  \  |  `   |
-// | SHFT |     |     |     |     |     |   |  _  |  +  |  {  |  }  | "|" |  ~   |
-//                    | GUI |     | SPC |   | ENT |     | ALT |
-                        bindings = <
-   &kp  TAB  &kp EXCL &kp AT &kp HASH &kp DLLR &kp PRCNT   &kp CARET &kp AMPS  &kp KP_MULTIPLY &kp LPAR &kp RPAR &kp BSPC
-   &kp LCTRL &trans   &trans &trans   &trans   &trans      &kp MINUS &kp EQUAL &kp LBKT        &kp RBKT &kp BSLH &kp GRAVE
-   &kp LSHFT &trans   &trans &trans   &trans   &trans      &kp UNDER &kp PLUS  &kp LBRC        &kp RBRC &kp PIPE &kp TILDE
-                             &kp LGUI &trans   &kp SPACE   &kp RET   &trans    &kp RALT
-                        >;
-                };
+    behaviors {
+        mo_tog: behavior_mo_tog {
+            compatible = "zmk,behavior-hold-tap";
+            label = "mo_tog";
+            #binding-cells = <2>;
+            flavor = "hold-preferred";
+            tapping-term-ms = <200>;
+            bindings = <&mo>, <&tog>;
         };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        default_layer {
+            bindings = <
+                &mo_tog 2 1     // &mo 2 on hold, &tog 1 on tap
+                MO_TOG(3)       // &mo 3 on hold, &tog 3 on tap
+            >;
+        };
+    };
 };
+//******************************************************************************
+
+// SAMPLE CODE 02: HOMEROW MODS
+// https://zmk.dev/docs/behaviors/hold-tap#option-1-cross-hand-only-modifiers-using-tap-unless-interrupted-and-positional-hold-tap-hold-trigger-key-positions
+// Option 1: cross-hand only modifiers, using tap-unless-interrupted and positional hold-tap (hold-trigger-key-positions)
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+
+/ {
+    behaviors {
+        lh_pht: left_hand_positional_hold_tap {
+            compatible = "zmk,behavior-hold-tap";
+            label = "LEFT_POSITIONAL_HOLD_TAP";
+            #binding-cells = <2>;
+            flavor = "tap-unless-interrupted";
+            tapping-term-ms = <100>;                        // <---[[produces tap if held longer than tapping-term-ms]]
+            quick-tap-ms = <200>;
+            bindings = <&kp>, <&kp>;
+            hold-trigger-key-positions = <5 6 7 8 9 10>;    // <---[[right-hand keys]]
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        default_layer {
+            bindings = <
+                // position 0     pos 1             pos 2             pos 3             pos 4    pos 5    pos 6    pos 7    pos 8    pos 9    pos 10
+                &lh_pht LSFT A    &lh_pht LGUI S    &lh_pht LALT D    &lh_pht LCTL F    &kp G    &kp H    &kp I    &kp J    &kp K    &kp L    &kp SEMI
+            >;
+        };
+    };
+};
+//******************************************************************************
+
+// SAMPLE CODE 03: HOMEROW MODS
+// https://zmk.dev/docs/behaviors/hold-tap#option-2-tap-preferred
+// Option 2: tap-preferred
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+
+/ {
+    behaviors {
+        hm: homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HOMEROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <150>;
+            quick-tap-ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        default_layer {
+            bindings = <
+                &hm LCTRL A &hm LGUI S &hm LALT D &hm LSHIFT F
+            >;
+        };
+    };
+};
+//******************************************************************************
+
+// SAMPLE CODE 04: HOMEROW MODS
+// https://zmk.dev/docs/behaviors/hold-tap#option-3-balanced
+// Option 3: balanced
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+
+/ {
+    behaviors {
+        bhm: balanced_homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HOMEROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;    // <---[[moderate duration]]
+            quick-tap-ms = <0>;
+            flavor = "balanced";
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        default_layer {
+            bindings = <
+                &bhm LCTRL A &bhm LGUI S &bhm LALT D &bhm LSHIFT F
+            >;
+        };
+    };
+};
+//******************************************************************************
+
+// SAMPLE CODE 05: MOD-MORPH
+// https://zmk.dev/docs/behaviors/mod-morph#mod-morph
+// Tapping sends first keypress
+// Tapping while holding the specified modifier sends second keypress
+// For Mac, adding this keypress will help with rotating between windows using
+// GUI + GRAVE
+// Already existing in ZMK: &gresc
+// Sample to have GRAVE/ESCAPE on a single key
+/ {
+    behaviors {
+        gresc: grave_escape {
+            compatible = "zmk,behavior-mod-morph";
+            label = "GRAVE_ESCAPE";
+            #binding-cells = <0>;
+            bindings = <&kp ESC>, <&kp GRAVE>;
+            mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
+        };
+    };
+};
+*/
+  // BEHAVIOR DEFINITIONS - START **********************************************
+  // Homerow mod definition for left hand keys
+  behaviors {
+    /***********************************************
+     **  Homerow mod for left split keyboard
+     **  as explained here: https://github.com/urob/zmk-config#timeless-homerow-mods
+     **  This is a expanded version of the same functionality along with the timings
+     ***********************************************/
+    hml: homerow_mod_left {
+      label = "HOMEROW_MOD_LEFT";
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      bindings = <&kp>, <&kp>;
+      flavor = "balanced";
+      tapping-term-ms = <280>;
+      quick-tap-ms = <QUICK_TAP_MS>;
+      require-prior-idle-ms = <150>;
+      hold-trigger-key-positions = <RIGHT_HAND_KEYS THUMB_KEYS>;
+      hold-trigger-on-release;
+    };
+    /***********************************************
+     **  Homerow mod for right split keyboard
+     **  as explained here: https://github.com/urob/zmk-config#timeless-homerow-mods
+     **  This is a expanded version of the same functionality along with the timings
+     ***********************************************/
+    hmr: homerow_mod_right {
+      label = "HOMEROW_MOD_RIGHT";
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      bindings = <&kp>, <&kp>;
+      flavor = "balanced";
+      tapping-term-ms = <280>;
+      quick-tap-ms = <QUICK_TAP_MS>;
+      require-prior-idle-ms = <150>;
+      hold-trigger-key-positions = <LEFT_HAND_KEYS THUMB_KEYS>;
+      hold-trigger-on-release;
+    };
+    /***********************************************
+     **  Homerow mod for left split keyboard using Bluetooth profile selection 
+     **  as explained here: https://github.com/urob/zmk-config#timeless-homerow-mods
+     **  This is a expanded version of the same functionality along with the timings
+     **  This behavior is used in the Bluetooth-Navigation layer only
+     ***********************************************/
+    hmlb: homerow_mod_left_bluetooth {
+      label = "HOMEROW_MOD_LEFT_BLUETOOTH";
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      bindings = <&kp>, <&bt>;
+      flavor = "balanced";
+      tapping-term-ms = <280>;
+      quick-tap-ms = <QUICK_TAP_MS>;
+      require-prior-idle-ms = <150>;
+      hold-trigger-key-positions = <RIGHT_HAND_KEYS THUMB_KEYS>;
+      hold-trigger-on-release;
+    };
+    /***********************************************
+     **  Smart Shift Key: As explained here: https://github.com/minusfive/zmk-config#smart-shift
+     **  This configuration is for the left split keyboard
+     **  Similar setup is defined for the right split keyboard
+     **     hold: shift
+     **     tap: sticky shift
+     **     double-tap: caps-word
+     ***********************************************/
+    ss_left: smart_shift_left {
+      label = "SMART_SHIFT_LEFT";
+      compatible = "zmk,behavior-mod-morph";
+      #binding-cells = <0>;
+      bindings = <&sk LSHFT>, <&caps_word>;
+      mods = <(MOD_LSFT)>;
+    };
+    /***********************************************
+     **  Smart Shift Key: As explained here: https://github.com/minusfive/zmk-config#smart-shift
+     **  This configuration is for the right split keyboard
+     **  Similar setup is defined for the left split keyboard
+     **     hold: shift
+     **     tap: sticky shift
+     **     double-tap: caps-word
+     ***********************************************/
+    ss_right: smart_shift_right {
+      label = "SMART_SHIFT_RIGHT";
+      compatible = "zmk,behavior-mod-morph";
+      #binding-cells = <0>;
+      bindings = <&sk RSHFT>, <&caps_word>;
+      mods = <(MOD_RSFT)>;
+    };
+    /***********************************************
+     **  Backspace Delete: As defined here: https://github.com/minusfive/zmk-config/blob/main/knucklehead/behaviors.dtsi
+     **     tap: backspace
+     **     hold: repeat backspace
+     **     shift + tap: delete
+     **     shift + hold: repeat delete
+     ***********************************************/
+    bkspc_del: backspace_delete {
+      label = "BACKSPACE_DELETE";
+      compatible = "zmk,behavior-mod-morph";
+      #binding-cells = <0>;
+      bindings = <&kp BACKSPACE>, <&kp DELETE>;
+      mods = <(MOD_LSFT|MOD_RSFT)>;
+    };
+    /***********************************************
+     **  ESC Grave:
+     **     tap: ESCAPE (ESC)
+     **     hold: repeat ESCAPE (ESC)
+     **     gui/command + tap: command + grave (~)
+     **     gui/command + : repeat command + grave (~)
+     ***********************************************/
+    escgrv: escape_grave {
+      compatible = "zmk,behavior-mod-morph";
+      label = "ESCAPE_GRAVE";
+      #binding-cells = <0>;
+      bindings = <&kp ESC>, <&kp GRAVE>;
+      mods = <(MOD_LGUI|MOD_RGUI)>;
+      keep-mods = <(MOD_LGUI|MOD_RGUI)>;
+    };
+    /***********************************************
+     **  Caret Exclamation:
+     **     tap: caret (^)
+     **     hold: repeat caret (^)
+     **     shift + tap: exclamation (!)
+     **     shift + hold: repeat exclamation (!)
+     ***********************************************/
+    cart_excl: caret_exclamation {
+      label = "CARET_EXCLAMATION";
+      compatible = "zmk,behavior-mod-morph";
+      #binding-cells = <0>;
+      bindings = <&kp CARET>, <&kp EXCL>;
+      mods = <(MOD_LSFT|MOD_RSFT)>;
+    };
+    /***********************************************
+     **  At Ampersand:
+     **     tap: ampersand (&)
+     **     hold: repeat ampersand (&)
+     **     shift + tap: at (@)
+     **     shift + hold: repeat at (@)
+     ***********************************************/
+    amp_at: ampersand_at {
+      label = "AMPERSAND_AT";
+      compatible = "zmk,behavior-mod-morph";
+      #binding-cells = <0>;
+      bindings = <&kp AMPS>, <&kp AT>;
+      mods = <(MOD_LSFT|MOD_RSFT)>;
+    };
+    /***********************************************
+     **  Star Hash:
+     **     tap: star (*)
+     **     hold: repeat star (*)
+     **     shift + tap: hash (#)
+     **     shift + hold: repeat hash (#)
+     ***********************************************/
+    star_hash: star_hash {
+      label = "STAR_HASH";
+      compatible = "zmk,behavior-mod-morph";
+      #binding-cells = <0>;
+      bindings = <&kp STAR>, <&kp HASH>;
+      mods = <(MOD_LSFT|MOD_RSFT)>;
+    };
+    /***********************************************
+     **  Left Parenthesis Dollar:
+     **     tap: left parenthesis (()
+     **     hold: repeat left parenthesis (()
+     **     shift + tap: dollar ($)
+     **     shift + hold: repeat dollar ($)
+     ***********************************************/
+    lpar_dllr: l_parenthesis_dollar {
+      label = "LEFT_PARENTHESIS_DOLLAR";
+      compatible = "zmk,behavior-mod-morph";
+      #binding-cells = <0>;
+      bindings = <&kp LPAR>, <&kp DOLLAR>;
+      mods = <(MOD_LSFT|MOD_RSFT)>;
+    };
+    /***********************************************
+     **  Right Parenthesis Percent:
+     **     tap: right parenthesis ())
+     **     hold: repeat right parenthesis ())
+     **     shift + tap: percent (%)
+     **     shift + hold: repeat percent (%)
+     ***********************************************/
+    rpar_prcnt: r_parenthesis_percent {
+      label = "RIGHT_PARENTHESIS_PERCENT";
+      compatible = "zmk,behavior-mod-morph";
+      #binding-cells = <0>;
+      bindings = <&kp RPAR>, <&kp PERCENT>;
+      mods = <(MOD_LSFT|MOD_RSFT)>;
+    };
+    /***********************************************
+     **  SPACE COMMAND LAYER FUN/NUM: On the left key board
+     **     tap: space
+     **     hold: command
+     **     double tap: toggle layer
+     ***********************************************/
+    s_c_fn_l: space_cmd_funnum_left {
+      label = "SPACE_CMD_FUNNUM_LEFT";
+      compatible = "zmk,behavior-tap-dance";
+      #binding-cells = <0>;
+      tapping-term-ms = <200>;
+      bindings = <&mt LGUI SPACE>, <&tog FN__NUM>;
+    };
+    /***********************************************
+     **  SPACE COMMAND LAYER SYMBOLS: On the right key board
+     **     tap: space
+     **     hold: command
+     **     double tap: toggle layer
+     ***********************************************/
+    s_c_sym_r: space_cmd_sym_right {
+      label = "SPACE_CMD_SYMBOLS_RIGHT";
+      compatible = "zmk,behavior-tap-dance";
+      #binding-cells = <0>;
+      tapping-term-ms = <200>;
+      bindings = <&mt RGUI SPACE>, <&tog SYMBOLS>;
+    };
+    /***********************************************
+     **  CONTROL LAYER BT__NAV: On the left key board
+     **     tap: none
+     **     hold: control
+     **     double tap: toggle layer
+     ***********************************************/
+    c_btnav_l: cntrl_bt_nav_left {
+      label = "CONTROL_BT_NAV_LEFT";
+      compatible = "zmk,behavior-tap-dance";
+      #binding-cells = <0>;
+      tapping-term-ms = <200>;
+      bindings = <&mt LCTRL XXX>, <&tog BT__NAV>;
+    };
+    /***********************************************
+     **  CONTROL LAYER COLEMAKDH: On the right key board
+     **     tap: none
+     **     hold: control
+     **     double tap: toggle layer
+     ***********************************************/
+    c_cdh_r: ctrl_cdh_right {
+      label = "CONTROL_COLEMAKDH_RIGHT";
+      compatible = "zmk,behavior-tap-dance";
+      #binding-cells = <0>;
+      tapping-term-ms = <200>;
+      bindings = <&mt LCTRL XXX>, <&tog CDH__BT>;
+    };
+  };
+  // BEHAVIOR DEFINITIONS - END ************************************************
+// BEHAVIOR - ENDS *************************************************************
+
+// MACROS - START **************************************************************
+/* ** Macro definition currently not in use
+ ** Place holder only.
+ ** Will be used later for switching between my personal Mac and Windows system switching
+    macros {
+      con_bt: con_bt {
+        label = "con_bt";
+        compatible = "zmk,behavior-macro";
+        #binding-cells = <0>;
+        bindings
+          = <&macro_tap &bt BT_SEL 0>
+          , <&macro_tap &tog 0>
+        ;
+      };
+      
+      con_usb: con_usb {
+        label = "con_usb";
+        compatible = "zmk,behavior-macro";
+        #binding-cells = <0>;
+        bindings
+          = <&macro_tap &out OUT_USB>
+          , <&macro_tap &tog 1>
+        ;
+      };
+    };
+*/
+// MACROS - ENDS ***************************************************************
+
+
+// KEYMAP NODE - START *********************************************************
+  keymap {
+    compatible = "zmk,keymap";
+    // LAYERS - START **********************************************************
+    // QWERTY layer
+    qwerty_bt_layer {
+      label = "QWT__BT";
+      bindings = <
+// ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮   ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮
+// ├─   0 <LT5>   ─┼─   1 <LT4>   ─┼─   2 <LT3>   ─┼─   3 <LT2>   ─┼─   4 <LT1>   ─┼─   5 <LT0>   ─┤   ├─   6 <RT0>   ─┼─   7 <RT1>   ─┼─   8 <RT2>   ─┼─   9 <RT3>   ─┼─  10 <RT4>   ─┼─  11 <RT5>   ─┤
+// ├─   ESC / ~   ─┼─      Q      ─┼─      W      ─┼─      E      ─┼─      R      ─┼─      T      ─┤   ├─      Y      ─┼─      U      ─┼─      I      ─┼─      O      ─┼─      P      ─┼─ <BKSPC/DEL> ─┤
+        &escgrv           &kp Q           &kp W           &kp E           &kp R           &kp T              &kp Y            &kp U           &kp I           &kp O           &kp P         &bkspc_del
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  12 <LM5>   ─┼─  13 <LM4>   ─┼─  14 <LM3>   ─┼─  15 <LM2>   ─┼─  16 <LM1>   ─┼─  17 <LM0>   ─┤   ├─  18 <RM0>   ─┼─  19 <RM1>   ─┼─  20 <RM2>   ─┼─  21 <RM3>   ─┼─  22 <RM4>   ─┼─  23 <RM5>   ─┤
+// ├─     TAB     ─┼─  LCTRL / A  ─┼─  LALT / S   ─┼─  LGUI / D   ─┼─  LSHFT / F  ─┼─      G      ─┤   ├─      H      ─┼─  RSHFT / J  ─┼─  RGUI / K   ─┼─  RALT / L   ─┼─  RCTRL / ;  ─┼─    RETURN   ─┤
+        &kp TAB      &hml LCTRL A     &hml LALT S     &hml LGUI D     &hml LSHFT F       &kp G               &kp H        &hmr RSHFT J    &hmr RGUI K     &hmr RALT L   &hmr RCTRL SEMI      &kp RET
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  24 <LB5>   ─┼─  25 <LB4>   ─┼─  26 <LB3>   ─┼─  27 <LB2>   ─┼─  28 <LB1>   ─┼─  29 <LB0>   ─┤   ├─  30 <RB0>   ─┼─  31 <RB1>   ─┼─  32 <RB2>   ─┼─  33 <RB3>   ─┼─  34 <RB4>   ─┼─  35 <RB5>   ─┤
+// ├─ SMART SHIFT ─┼─      Z      ─┼─      X      ─┼─      C      ─┼─      V      ─┼─      B      ─┤   ├─      N      ─┼─      M      ─┼─      ,      ─┼─      .      ─┼─      /      ─┼─ SMART SHIFT ─┤
+       &ss_left          &kp Z           &kp X           &kp C           &kp V           &kp B               &kp N           &kp M         &kp COMMA        &kp DOT        &kp FSLH        &ss_right
+// ╰───────────────┴───────────────┴───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┴───────────────┴───────────────╯
+//                                                 ├─  36 <LH2>   ─┼─  37 <LH1>   ─┼─  38 <LH0>   ─┤   ├─  39 <RH0>   ─┼─  40 <RH1>   ─┼─  41 <RH2>   ─┤
+//                                                 ├─   ALT/OPT   ─┼─CTRL/X/BT_NAV─┼─ SPC/CMD/FN  ─┤   ├─ SPC/CMD/FN  ─┼─CTRL/X/CDH_BT─┼─   ALT/OPT   ─┤
+                                                       &sk LALT        &c_btnav_l       &s_c_fn_l          &s_c_sym_r      &c_cdh_r        &sk RALT
+//                                                 ╰───────────────┴───────────────┴───────────────╯   ╰───────────────┴───────────────┴───────────────╯
+      >;
+    };
+
+
+    // Function and Number layer
+    function_number_layer {
+      label = "FN__NUM";
+      bindings = <
+// ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮   ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮
+// ├─   0 <LT5>   ─┼─   1 <LT4>   ─┼─   2 <LT3>   ─┼─   3 <LT2>   ─┼─   4 <LT1>   ─┼─   5 <LT0>   ─┤   ├─   6 <RT0>   ─┼─   7 <RT1>   ─┼─   8 <RT2>   ─┼─   9 <RT3>   ─┼─  10 <RT4>   ─┼─  11 <RT5>   ─┤
+// ├─    ` / ~    ─┼─      F1     ─┼─      F2     ─┼─      F3     ─┼─      F4     ─┼─     NONE    ─┤   ├─      /      ─┼─       7     ─┼─       8     ─┼─       9     ─┼─       *     ─┼─ <BKSPC/DEL> ─┤
+       &kp GRAVE        &kp F1          &kp F2          &kp F3          &kp F4            XXX             &kp FSLH         &kp N7          &kp N8          &kp N9         &kp STAR       &bkspc_del
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  12 <LM5>   ─┼─  13 <LM4>   ─┼─  14 <LM3>   ─┼─  15 <LM2>   ─┼─  16 <LM1>   ─┼─  17 <LM0>   ─┤   ├─  18 <RM0>   ─┼─  19 <RM1>   ─┼─  20 <RM2>   ─┼─  21 <RM3>   ─┼─  22 <RM4>   ─┼─  23 <RM5>   ─┤
+// ├─     TAB     ─┼─  LCTRL / F5 ─┼─  LALT / F6  ─┼─  LGUI / F7  ─┼─  LSHFT / F8 ─┼─     NONE    ─┤   ├─      .      ─┼─       4     ─┼─       5     ─┼─       6     ─┼─       -     ─┼─    RETURN   ─┤
+        &kp TAB      &hml LCTRL F5    &hml LALT F6    &hml LGUI F7   &hml LSHFT F8        XXX             &kp DOT          &kp N4          &kp N5          &kp N6        &kp MINUS        &kp RET
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  24 <LB5>   ─┼─  25 <LB4>   ─┼─  26 <LB3>   ─┼─  27 <LB2>   ─┼─  28 <LB1>   ─┼─  29 <LB0>   ─┤   ├─  30 <RB0>   ─┼─  31 <RB1>   ─┼─  32 <RB2>   ─┼─  33 <RB3>   ─┼─  34 <RB4>   ─┼─  35 <RB5>   ─┤
+// ├─ SMART SHIFT ─┼─      F9     ─┼─     F10     ─┼─      F11    ─┼─      F12    ─┼─     NONE    ─┤   ├─       0     ─┼─       1     ─┼─       2     ─┼─       3     ─┼─       +     ─┼─ SMART SHIFT ─┤
+       &ss_left         &kp F9          &kp F10         &kp F11          &kp F12          XXX              &kp N0          &kp N1          &kp N2          &kp N3         &kp PLUS        &ss_right
+// ╰───────────────┴───────────────┴───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┴───────────────┴───────────────╯
+//                                                 ├─  36 <LH2>   ─┼─  37 <LH1>   ─┼─  38 <LH0>   ─┤   ├─  39 <RH0>   ─┼─  40 <RH1>   ─┼─  41 <RH2>   ─┤
+//                                                 ├─   ALT/OPT   ─┼─CTRL/X/BT_NAV─┼─ SPC/CMD/FN  ─┤   ├─ SPC/CMD/FN  ─┼─CTRL/X/QWT_BT─┼─   ALT/OPT   ─┤
+                                                       &sk LALT        &c_btnav_l       &s_c_fn_l          &s_c_sym_r      &c_cdh_r        &sk RALT
+//                                                 ╰───────────────┴───────────────┴───────────────╯   ╰───────────────┴───────────────┴───────────────╯
+      >;
+    };
+
+    // Symbols layer
+    symbols_layer {
+      label = "SYMBOLS";
+      bindings = <
+// ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮   ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮
+// ├─   0 <LT5>   ─┼─   1 <LT4>   ─┼─   2 <LT3>   ─┼─   3 <LT2>   ─┼─   4 <LT1>   ─┼─   5 <LT0>   ─┤   ├─   6 <RT0>   ─┼─   7 <RT1>   ─┼─   8 <RT2>   ─┼─   9 <RT3>   ─┼─  10 <RT4>   ─┼─  11 <RT5>   ─┤
+// ├─    ` / ~    ─┼─      !      ─┼─      @      ─┼─      #      ─┼─      $      ─┼─      %      ─┤   ├─    ! / ^    ─┼─    @ / &    ─┼─    # / *    ─┼─    $ / (    ─┼─    % / )    ─┼─ <BKSPC/DEL> ─┤
+       &kp GRAVE       &kp EXCL         &kp AT         &kp HASH        &kp DLLR        &kp PRCNT           &cart_excl       &amp_at        &star_hash      &lpar_dllr     &rpar_prcnt      &bkspc_del
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  12 <LM5>   ─┼─  13 <LM4>   ─┼─  14 <LM3>   ─┼─  15 <LM2>   ─┼─  16 <LM1>   ─┼─  17 <LM0>   ─┤   ├─  18 <RM0>   ─┼─  19 <RM1>   ─┼─  20 <RM2>   ─┼─  21 <RM3>   ─┼─  22 <RM4>   ─┼─  23 <RM5>   ─┤
+// ├─     TAB     ─┼─  LCTRL / _  ─┼─  LALT / +   ─┼─  LGUI / {   ─┼─  LSHFT / }  ─┼─      |      ─┤   ├─    - / _    ─┼─RSHFT / = / +─┼─ RGUI / [ / {─┼─ RALT / ] / }─┼─RCTRL / \ / |─┼─    RETURN   ─┤
+        &kp TAB     &hml LCTRL UNDER &hml LALT PLUS  &hml LGUI LBRC &hml LSHFT RBRC    &kp PIPE           &kp MINUS     &hmr RSHFT EQUAL &hmr RGUI LBKT  &hmr RALT LBKT &hmr RCTRL BSLH     &kp RET
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  24 <LB5>   ─┼─  25 <LB4>   ─┼─  26 <LB3>   ─┼─  27 <LB2>   ─┼─  28 <LB1>   ─┼─  29 <LB0>   ─┤   ├─  30 <RB0>   ─┼─  31 <RB1>   ─┼─  32 <RB2>   ─┼─  33 <RB3>   ─┼─  34 <RB4>   ─┼─  35 <RB5>   ─┤
+// ├─ SMART SHIFT ─┼─      :      ─┼─      "      ─┼─      <      ─┼─      >      ─┼─      ?      ─┤   ├─    ; / :    ─┼─    ' / "    ─┼─    , / <    ─┼─    . / >    ─┼─   / / ?     ─┼─ SMART SHIFT ─┤
+       &ss_left        &kp COLON        &kp DQT         &kp LT          &kp GT         &kp QMARK           &kp SEMI         &kp SQT        &kp COMMA        &kp DOT        &kp FSLH        &ss_right
+// ╰───────────────┴───────────────┴───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┴───────────────┴───────────────╯
+//                                                 ├─  36 <LH2>   ─┼─  37 <LH1>   ─┼─  38 <LH0>   ─┤   ├─  39 <RH0>   ─┼─  40 <RH1>   ─┼─  41 <RH2>   ─┤
+//                                                 ├─   ALT/OPT   ─┼─CTRL/X/BT_NAV─┼─ SPC/CMD/FN  ─┤   ├─ SPC/CMD/FN  ─┼─CTRL/X/QWT_BT─┼─   ALT/OPT   ─┤
+                                                       &sk LALT        &c_btnav_l       &s_c_fn_l          &s_c_sym_r      &c_cdh_r        &sk RALT
+//                                                 ╰───────────────┴───────────────┴───────────────╯   ╰───────────────┴───────────────┴───────────────╯
+      >;
+    };
+
+    // Bluetooth and Navigation layer
+    bt_navigation_layer {
+      label = "BT__NAV";
+      bindings = <
+// ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮   ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮
+// ├─   0 <LT5>   ─┼─   1 <LT4>   ─┼─   2 <LT3>   ─┼─   3 <LT2>   ─┼─   4 <LT1>   ─┼─   5 <LT0>   ─┤   ├─   6 <RT0>   ─┼─   7 <RT1>   ─┼─   8 <RT2>   ─┼─   9 <RT3>   ─┼─  10 <RT4>   ─┼─  11 <RT5>   ─┤
+// ├─   ESC / ~   ─┼─   OUT USB   ─┼─  BOOTLOADER ─┼─    BT CLR   ─┼─    RESET    ─┼─   OUT BLE   ─┤   ├─     HOME    ─┼─     NONE    ─┼─      UP     ─┼─    NONE     ─┼─    PG UP    ─┼─ <BKSPC/DEL> ─┤
+        &escgrv        &out OUT_USB    &bootloader      &bt BT_CLR      &sys_reset     &out OUT_BLE          &kp HOME           XXX          &kp UP            XXX          &kp PG_UP       &bkspc_del
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  12 <LM5>   ─┼─  13 <LM4>   ─┼─  14 <LM3>   ─┼─  15 <LM2>   ─┼─  16 <LM1>   ─┼─  17 <LM0>   ─┤   ├─  18 <RM0>   ─┼─  19 <RM1>   ─┼─  20 <RM2>   ─┼─  21 <RM3>   ─┼─  22 <RM4>   ─┼─  23 <RM5>   ─┤
+// ├─     TAB     ─┼─ LCTRL / NONE─┼─ LALT / NONE ─┼─  LGUI / NONE─┼─ LSHFT / NONE─┼─     NONE    ─┤   ├─     END     ─┼─ RSHFT / LEFT─┼─ RGUI / DOWN ─┼─ RALT / RIGHT─┼─RCTRL / PG DN─┼─    RETURN   ─┤
+        &kp TAB     &hml LCTRL XXX   &hml LALT XXX   &hml LGUI XXX   &hml LSHFT XXX       XXX               &kp END     &hmr RSHFT LEFT  &hmr RGUI DOWN &hmr RALT RIGHT &hmr RCTRL PG_DN     &kp RET
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  24 <LB5>   ─┼─  25 <LB4>   ─┼─  26 <LB3>   ─┼─  27 <LB2>   ─┼─  28 <LB1>   ─┼─  29 <LB0>   ─┤   ├─  30 <RB0>   ─┼─  31 <RB1>   ─┼─  32 <RB2>   ─┼─  33 <RB3>   ─┼─  34 <RB4>   ─┼─  35 <RB5>   ─┤
+// ├─ SMART SHIFT ─┼─      BT0    ─┼─      BT1    ─┼─      BT2    ─┼─     BT3     ─┼─      BT4    ─┤   ├─     NONE    ─┼─     NONE    ─┼─     NONE    ─┼─     NONE    ─┼─     NONE    ─┼─ SMART SHIFT ─┤
+       &ss_left       &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4            XXX             XXX             XXX             XXX             XXX          &ss_right
+// ╰───────────────┴───────────────┴───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┴───────────────┴───────────────╯
+//                                                 ├─  36 <LH2>   ─┼─  37 <LH1>   ─┼─  38 <LH0>   ─┤   ├─  39 <RH0>   ─┼─  40 <RH1>   ─┼─  41 <RH2>   ─┤
+//                                                 ├─   ALT/OPT   ─┼─CTRL/X/BT_NAV─┼─ SPC/CMD/FN  ─┤   ├─ SPC/CMD/FN  ─┼─CTRL/X/QWT_BT─┼─   ALT/OPT   ─┤
+                                                       &sk LALT        &c_btnav_l      &s_c_fn_l          &s_c_sym_r        &c_cdh_r        &sk RALT
+//                                                 ╰───────────────┴───────────────┴───────────────╯   ╰───────────────┴───────────────┴───────────────╯
+      >;
+    };
+    // Colemak Mod-DH: Primary layer. To learn and and use
+    colemakdh_bt_layer {
+      label = "CDH__BT";
+      bindings = <
+// ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮   ╭───────────────┬───────────────┬───────────────┬───────────────┬───────────────┬───────────────╮
+// ├─   0 <LT5>   ─┼─   1 <LT4>   ─┼─   2 <LT3>   ─┼─   3 <LT2>   ─┼─   4 <LT1>   ─┼─   5 <LT0>   ─┤   ├─   6 <RT0>   ─┼─   7 <RT1>   ─┼─   8 <RT2>   ─┼─   9 <RT3>   ─┼─  10 <RT4>   ─┼─  11 <RT5>   ─┤
+// ├─   ESC / ~   ─┼─      Q      ─┼─      W      ─┼─      F      ─┼─      P      ─┼─      B      ─┤   ├─      J      ─┼─      L      ─┼─      U      ─┼─      Y      ─┼─      ;      ─┼─ <BKSPC/DEL> ─┤
+        &escgrv          &kp Q           &kp W           &kp F           &kp P           &kp B              &kp J            &kp L           &kp U           &kp Y         &kp SEMI       &bkspc_del
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  12 <LM5>   ─┼─  13 <LM4>   ─┼─  14 <LM3>   ─┼─  15 <LM2>   ─┼─  16 <LM1>   ─┼─  17 <LM0>   ─┤   ├─  18 <RM0>   ─┼─  19 <RM1>   ─┼─  20 <RM2>   ─┼─  21 <RM3>   ─┼─  22 <RM4>   ─┼─  23 <RM5>   ─┤
+// ├─     TAB     ─┼─  LCTRL / A  ─┼─  LALT / R   ─┼─  LGUI / S   ─┼─  LSHFT / T  ─┼─      G      ─┤   ├─      M      ─┼─  RSHFT / N  ─┼─  RGUI / E   ─┼─  RALT / I   ─┼─  RCTRL / O  ─┼─    RETURN   ─┤
+        &kp TAB      &hml LCTRL A     &hml LALT R     &hml LGUI S     &hml LSHFT T       &kp G               &kp M        &hmr RSHFT N    &hmr RGUI E     &hmr RALT I     &hmr RCTRL O      &kp RET
+// ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┼───────────────┼───────────────┤
+// ├─  24 <LB5>   ─┼─  25 <LB4>   ─┼─  26 <LB3>   ─┼─  27 <LB2>   ─┼─  28 <LB1>   ─┼─  29 <LB0>   ─┤   ├─  30 <RB0>   ─┼─  31 <RB1>   ─┼─  32 <RB2>   ─┼─  33 <RB3>   ─┼─  34 <RB4>   ─┼─  35 <RB5>   ─┤
+// ├─ SMART SHIFT ─┼─      z      ─┼─      x      ─┼─      C      ─┼─      D      ─┼─      V      ─┤   ├─      K      ─┼─      H      ─┼─      ,      ─┼─      .      ─┼─      /      ─┼─ SMART SHIFT ─┤
+       &ss_left         &kp Z           &kp X           &kp C           &kp D            &kp V               &kp K           &kp H         &kp COMMA        &kp DOT        &kp FSLH        &ss_right
+// ╰───────────────┴───────────────┴───────────────┼───────────────┼───────────────┼───────────────┤   ├───────────────├───────────────┼───────────────┼───────────────┴───────────────┴───────────────╯
+//                                                 ├─  36 <LH2>   ─┼─  37 <LH1>   ─┼─  38 <LH0>   ─┤   ├─  39 <RH0>   ─┼─  40 <RH1>   ─┼─  41 <RH2>   ─┤
+//                                                 ├─   ALT/OPT   ─┼─CTRL/X/BT_NAV─┼─ SPC/CMD/FN  ─┤   ├─ SPC/CMD/FN  ─┼─CTRL/X/QWT_BT─┼─   ALT/OPT   ─┤
+                                                       &sk LALT        &c_btnav_l       &s_c_fn_l          &s_c_sym_r      &c_cdh_r        &sk RALT
+//                                                 ╰───────────────┴───────────────┴───────────────╯   ╰───────────────┴───────────────┴───────────────╯
+      >;
+    };
+
+// LAYERS - ENDS ***************************************************************
+  };
+// KEYMAP NODE - ENDS **********************************************************
+};
+// ROOT DEVICETREE NODE - ENDS *************************************************

--- a/config/corne_42keys.h
+++ b/config/corne_42keys.h
@@ -1,0 +1,76 @@
+/*******************************************************************************
+  42 KEY MATRIX / LAYOUT MAPPING - Taken from urob's keypos file
+  Used for the Timerless Homerow Mod configuration
+  ╭────────────────────────┬────────────────────────╮
+  │  0   1   2   3   4   5 │  6   7   8   9  10  11 │
+  │ 12  13  14  15  16  17 │ 18  19  20  21  22  23 │
+  │ 24  25  26  27  28  29 │ 30  31  32  33  34  35 │
+  ╰───────────╮ 36  37  38 │ 39  40  41 ╭───────────╯
+              ╰────────────┴────────────╯
+  ╭─────────────────────────┬─────────────────────────╮
+  │ LT5 LT4 LT3 LT2 LT1 LT0 │ RT0 RT1 RT2 RT3 RT4 RT5 │
+  │ LM5 LM4 LM3 LM2 LM1 LM0 │ RM0 RM1 RM2 RM3 RM4 RM5 │
+  │ LB5 LB4 LB3 LB2 LB1 LB0 │ RB0 RB1 RB2 RB3 RB4 RB5 │
+  ╰───────────╮ LH2 LH1 LH0 │ RH0 RH1 RH2 ╭───────────╯
+              ╰─────────────┴─────────────╯
+*******************************************************************************/
+
+#pragma once
+
+// Left Top Row
+#define LT0 5
+#define LT1 4
+#define LT2 3
+#define LT3 2
+#define LT4 1
+#define LT5 0
+
+// Right Top Row
+#define RT0 6
+#define RT1 7
+#define RT2 8
+#define RT3 9
+#define RT4 10
+#define RT5 11
+
+// Left Middle Row
+#define LM0 17
+#define LM1 16
+#define LM2 15
+#define LM3 14
+#define LM4 13
+#define LM5 12
+
+// Right Middle Row
+#define RM0 18
+#define RM1 19
+#define RM2 20
+#define RM3 21
+#define RM4 22
+#define RM5 23
+
+// Left Bottom Row
+#define LB0 29
+#define LB1 28
+#define LB2 27
+#define LB3 26
+#define LB4 25
+#define LB5 24
+
+// Right Bottom Row
+#define RB0 30
+#define RB1 31
+#define RB2 32
+#define RB3 33
+#define RB4 34
+#define RB5 35
+
+// Left Thumb Row
+#define LH0 38
+#define LH1 37
+#define LH2 36
+
+// Right Thumb Row
+#define RH0 39
+#define RH1 40
+#define RH2 41


### PR DESCRIPTION
* Defined the layers for the intial use defined.
* Added some sample code which will be included in the final version of the code.
* Updated the README file with the details for the next release.
* Updated the README with preference for the release
* Added some more sample code for implementation of the keyboard.
* Create a new keyboard configuration using Colemak-modDH as the default layer.
* Added the QWERTY layer for backup.
* Added a Symbols layer, Number layer and Function & Bluetooth layer.
* Used various mod-morph behavior.
* Added various configurations from the following repos:
   * https://github.com/urob/zmk-config
   * https://github.com/minusfive/zmk-config
* Removed the homerow mods for the Bluetooth layer on the left split keyboard
* Added the Bluetooth profile selection defines for use in homerow mods
* Updated the mod-morph reference for Grave/Escape key sequence
* Updated the Homerow mods for BT layer to only work as control keys.
* Moved the BT profile selection to the next left lower keys
* Reconfigured the Colemak and Qwerty layers
* Added the custom Escape-Grave key
* Updated the escgrave mod-morph to send the command key while using the mod